### PR TITLE
Changed VariantAdmin so that makes multipart post for iOS variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,7 @@ exception is the `id` filter: if the `id` is specified, all the other filters ar
 
 To create an application we will use the `create` method:
 ```typescript
-const newApp: PushApplication = {
-...
-};
-const app = upsadm.applications.create(newApp)
+const app = upsadm.applications.create('newApp')
 ```
 The returned `app` object will have all the `id` and `pushApplicationId` fields populated by the server.
 
@@ -96,6 +93,7 @@ To get the list of the variants, we will use
 ```typescript
 const apps = upsadm.variants.find(appId)
 ```
+where `appId` is the id of the application owning the variants.
 
 The find method takes as parameter the owner application id and, optionally, a filter parameter. Variants can be filtered by:
 * **id**

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,8 +932,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1483,7 +1482,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1739,8 +1737,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -2145,13 +2142,12 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -3681,14 +3677,12 @@
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-      "dev": true
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.43.0"
       }
@@ -4407,6 +4401,17 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/unifiedpush-admin-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "axios": "0.19.2"
+    "axios": "0.19.2",
+    "form-data": "3.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/unifiedpush-admin-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Client library used to admin UPS with code",
   "author": "AeroGear Team<aerogear@googlegroups.com>",
   "homepage": "http://aerogear.org",

--- a/src/UnifiedPushAdminClient.ts
+++ b/src/UnifiedPushAdminClient.ts
@@ -75,8 +75,7 @@ export class UnifiedPushAdminClient {
      * Creates an application in the UPS
      * @param app the application to be created
      */
-    create: async (app: PushApplication): Promise<PushApplication> =>
-      this.applicationsAdmin.create(await this.auth(), app),
+    create: async (name: string): Promise<PushApplication> => this.applicationsAdmin.create(await this.auth(), name),
   };
 
   readonly variants = {

--- a/src/applications/ApplicationsAdmin.ts
+++ b/src/applications/ApplicationsAdmin.ts
@@ -16,7 +16,7 @@ export class ApplicationsAdmin {
     }
   }
 
-  async create(api: AxiosInstance, app: PushApplication): Promise<PushApplication> {
-    return (await api.post(`/applications`, app)).data;
+  async create(api: AxiosInstance, name: string): Promise<PushApplication> {
+    return (await api.post(`/applications`, { name })).data;
   }
 }

--- a/test/UnifiedPushAdminClient.test.ts
+++ b/test/UnifiedPushAdminClient.test.ts
@@ -44,9 +44,9 @@ describe('Applications Admin', () => {
     const appToBeCreated = mockData[3];
     mockedAxios.post.mockImplementationOnce((url: string, app: PushApplication) => Promise.resolve({ data: app }));
 
-    const res = await new UnifiedPushAdminClient('http://localhost:9999').applications.create(appToBeCreated);
-    expect(res).toEqual(appToBeCreated);
-    expect(mockedAxios.post).toHaveBeenCalledWith('/applications', appToBeCreated);
+    const res = await new UnifiedPushAdminClient('http://localhost:9999').applications.create(appToBeCreated.name);
+    expect(res).toEqual({ name: appToBeCreated.name });
+    expect(mockedAxios.post).toHaveBeenCalledWith('/applications', { name: appToBeCreated.name });
   });
 });
 


### PR DESCRIPTION
## Motivation
Fixes #13
Fixes #14

## What
Changed the ApplicationAdmin class so that multipart post is done for `ios` variants

## Why
The `create` variant for the `ios` type requires a multipart post (all other endpoints require a normal post of a json file)
