### PR TITLE
Fixed variant delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UnifiedPush Server Admin Client
 
 ![Build](https://github.com/aerogear/unifiedpush-admin-client/workflows/build/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/aerogear/unifiedpush-admin-client/badge.svg)](https://coveralls.io/github/aerogear/unifiedpush-admin-client)
+[![Coverage Status](https://coveralls.io/repos/github/aerogear/unifiedpush-admin-client/badge.svg?branch=master)](https://coveralls.io/github/aerogear/unifiedpush-admin-client)
 
 The _UnifiedPush Server Admin_ library allows to admin the UPS by javascript or typescript code.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/unifiedpush-admin-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aerogear/unifiedpush-admin-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Client library used to admin UPS with code",
   "author": "AeroGear Team<aerogear@googlegroups.com>",
   "homepage": "http://aerogear.org",

--- a/src/variants/VariantsAdmin.ts
+++ b/src/variants/VariantsAdmin.ts
@@ -48,7 +48,9 @@ export class VariantsAdmin {
 
   async delete(api: AxiosInstance, appId: string, filter?: VariantFilter) {
     return Promise.all(
-      (await this.find(api, appId, filter)).map(variant => api.delete(`/applications/${appId}/${variant.variantID!}`))
+      (await this.find(api, appId, filter)).map(variant =>
+        api.delete(`/applications/${appId}/${variant.type}/${variant.variantID!}`).then(() => variant)
+      )
     );
   }
 }

--- a/test/UnifiedPushAdminClient.test.ts
+++ b/test/UnifiedPushAdminClient.test.ts
@@ -24,6 +24,7 @@ afterAll(() => {
 });
 
 const TEST_APP_ID = '2:2';
+const TEST_VARIANT_ID = 'v-2:1';
 
 describe('UnifiedPushAdminClient', () => {
   const credentials: KeycloakCredentials = {
@@ -53,5 +54,21 @@ describe('UnifiedPushAdminClient', () => {
       TEST_NEW_VARIANT_TO_CREATE
     );
     expect(variant).toEqual(TEST_NEW_VARIANT_CREATED);
+  });
+
+  it('Should delete a varianta', async () => {
+    const variantsBefore = await new UnifiedPushAdminClient(BASE_URL, credentials).variants.find(TEST_APP_ID, {
+      variantID: TEST_VARIANT_ID,
+    });
+    expect(variantsBefore).toBeDefined();
+    expect(variantsBefore).toHaveLength(1);
+    await new UnifiedPushAdminClient(BASE_URL, credentials).variants.delete(TEST_APP_ID, {
+      variantID: TEST_VARIANT_ID,
+    });
+    const variantsAfter = await new UnifiedPushAdminClient(BASE_URL, credentials).variants.find(TEST_APP_ID, {
+      variantID: TEST_VARIANT_ID,
+    });
+    expect(variantsAfter).toBeDefined();
+    expect(variantsAfter).toHaveLength(0);
   });
 });

--- a/test/mocks/nockMocks.ts
+++ b/test/mocks/nockMocks.ts
@@ -113,13 +113,13 @@ export const mockUps = (baseUrl = BASE_URL, auth = false) =>
       expect(requestBody.indexOf('name="certificate"')).not.toEqual(-1);
       return TEST_NEW_VARIANT_CREATED;
     })
-    .delete(/rest\/applications\/?[^\/]*\/?[^\/]*/)
+    .delete(/rest\/applications\/?[^\/]*\/?[^\/]*\/?[^\/]*/)
     // tslint:disable-next-line:only-arrow-functions
     .reply(200, function(uri, requestBody) {
-      const del = /rest\/applications\/?([^\/]*)\/?([^\/]*)/;
+      const del = /rest\/applications\/?([^\/]*)\/?([^\/]*)\/?([^\/]*)/;
       const params = del.exec(uri)!;
       const appid = params[1];
-      const varId = params[2];
+      const varId = params[3];
       const app = mockData.find(appDel => appDel.pushApplicationID === appid)!;
       const variants = app?.variants?.filter(variant => variant.variantID !== varId);
 


### PR DESCRIPTION
## Motivation
The delete command was trying to delete a variant by calling

http://UPSURL/rest/applications/{APP-ID}/{VARIANT-ID}

that's not the correct endpoint.

## What
Changed the delete command to call

http://UPSURL/rest/applications/{APP-ID}/{VARIANT-TYPE}/{VARIANT-ID}

and return the deleted variant(s).

## Why
Add an short answer for: Why it was done? (E.g The feature X was deprecated.)