### PR TITLE
feat(list)!: added management for the total header

### DIFF
--- a/src/UnifiedPushAdminClient.ts
+++ b/src/UnifiedPushAdminClient.ts
@@ -2,7 +2,7 @@ import axios, {AxiosInstance} from 'axios';
 import {PushApplication, PushApplicationSearchOptions} from './applications';
 import {Variant, VariantFilter} from './variants';
 import {VariantsAdmin} from './variants/VariantsAdmin';
-import {ApplicationsAdmin} from './applications/ApplicationsAdmin';
+import {ApplicationsAdmin, SearchResults} from './applications/ApplicationsAdmin';
 
 const DEFAULT_REALM = 'aerogear';
 const DEFAULT_CLIENT_ID = 'unified-push-server-js';
@@ -71,9 +71,8 @@ export class UnifiedPushAdminClient {
      * @param filter a filter to be used to find applications. If not specified, all applications are returned.
      * @param page the number of the page to be visualised
      */
-    find: async ({filter, page}: {filter?: PushApplicationSearchOptions; page?: number} = {}): Promise<
-      PushApplication[]
-    > => this.applicationsAdmin.find(await this.auth(), {filter, page}),
+    find: async ({filter, page}: {filter?: PushApplicationSearchOptions; page?: number} = {}): Promise<SearchResults> =>
+      this.applicationsAdmin.find(await this.auth(), {filter, page}),
     /**
      * Creates an application in the UPS
      * @param name the name of the application to be created
@@ -86,7 +85,7 @@ export class UnifiedPushAdminClient {
      * @param newName
      */
     rename: async (pushApplicationID: string, newName: string) => {
-      const app = (await this.applications.find({filter: {pushApplicationID}}))[0];
+      const app = (await this.applications.find({filter: {pushApplicationID}})).appList[0];
       app.name = newName;
       // Remove the variants
       app.variants = undefined;

--- a/src/applications/ApplicationsAdmin.ts
+++ b/src/applications/ApplicationsAdmin.ts
@@ -1,6 +1,11 @@
 import {AxiosInstance, AxiosResponse} from 'axios';
 import {applyPushApplicationFilter, PushApplication, PushApplicationSearchOptions} from './PushApplication';
 
+export interface SearchResults {
+  total: number;
+  appList: PushApplication[];
+}
+
 export class ApplicationsAdmin {
   readonly DEFAULT_PAGE_SIZE = 10;
 
@@ -11,9 +16,13 @@ export class ApplicationsAdmin {
       page = 0,
       pageSize = this.DEFAULT_PAGE_SIZE,
     }: {filter?: PushApplicationSearchOptions; page?: number; pageSize?: number} = {}
-  ): Promise<PushApplication[]> {
+  ): Promise<SearchResults> {
     let url = '/applications';
-    let apps: PushApplication[];
+
+    let result: SearchResults = {
+      appList: [],
+      total: 0,
+    };
 
     //////////////////////////////////////////////////////////////////////
     // Reads the activity from the headers and adds it to the app metadata
@@ -45,10 +54,22 @@ export class ApplicationsAdmin {
             per_page: pageSize,
           },
         });
-        apps = utils.ensureIsArray(response.data).map((app: PushApplication) => addActivityData(app, response));
+
+        const apps = utils.ensureIsArray(response.data).map((app: PushApplication) => addActivityData(app, response));
+
+        result = {
+          appList: apps,
+          total: apps.length,
+        };
       } else {
         // To filter on other fields than `id` we need to get ALL the applications from UPS
-        apps = utils.getPage(applyPushApplicationFilter(await utils.getAllApplications(api), filter), page, pageSize);
+        const appList = applyPushApplicationFilter(await utils.getAllApplications(api), filter);
+
+        result = {
+          total: appList.length,
+          appList,
+        };
+        result.appList = utils.getPage(result.appList, page, pageSize);
       }
     } else {
       // there is no filter, we can ask the page to the UPS
@@ -60,11 +81,12 @@ export class ApplicationsAdmin {
           per_page: pageSize,
         },
       });
-      apps = utils.ensureIsArray(response.data).map((app: PushApplication) => addActivityData(app, response));
+
+      result.total = parseInt(response.headers['total']);
+      result.appList = utils.ensureIsArray(response.data).map((app: PushApplication) => addActivityData(app, response));
     }
 
-    // filter the result
-    return apps;
+    return result;
   }
 
   async create(api: AxiosInstance, name: string): Promise<PushApplication> {
@@ -76,7 +98,7 @@ export class ApplicationsAdmin {
   }
   async delete(api: AxiosInstance, filter?: PushApplicationSearchOptions) {
     return Promise.all(
-      (await this.find(api, {filter})).map(application =>
+      (await this.find(api, {filter})).appList.map(application =>
         api.delete(`/applications/${application.pushApplicationID}`).then(() => application)
       )
     );

--- a/test/UnifiedPushAdminClient.test.ts
+++ b/test/UnifiedPushAdminClient.test.ts
@@ -27,7 +27,7 @@ describe('UnifiedPushAdminClient', () => {
   it('Should return all apps', async () => {
     utils.generateApps(upsMock, 10);
     const apps = await new UnifiedPushAdminClient(BASE_URL, credentials).applications.find();
-    expect(apps).toHaveLength(10);
+    expect(apps.appList).toHaveLength(10);
   });
 
   it('Should rename an app', async () => {
@@ -38,16 +38,14 @@ describe('UnifiedPushAdminClient', () => {
     const newName = 'NEW APP NAME';
 
     expect(
-      (
-        await new UnifiedPushAdminClient(BASE_URL, credentials).applications.find({filter: {pushApplicationID: appId}})
-      )[0].name
+      (await new UnifiedPushAdminClient(BASE_URL, credentials).applications.find({filter: {pushApplicationID: appId}}))
+        .appList[0].name
     ).not.toEqual(newName);
 
     await new UnifiedPushAdminClient(BASE_URL, credentials).applications.rename(appId, newName);
     expect(
-      (
-        await new UnifiedPushAdminClient(BASE_URL, credentials).applications.find({filter: {pushApplicationID: appId}})
-      )[0].name
+      (await new UnifiedPushAdminClient(BASE_URL, credentials).applications.find({filter: {pushApplicationID: appId}}))
+        .appList[0].name
     ).toEqual(newName);
   });
 
@@ -63,10 +61,10 @@ describe('UnifiedPushAdminClient', () => {
 
     const ups = new UnifiedPushAdminClient(BASE_URL, credentials);
     const app = await ups.applications.find({filter: {name: appToDelete.name}});
-    expect(app).toHaveLength(1);
+    expect(app.appList).toHaveLength(1);
     const deletedApp = await ups.applications.delete({name: appToDelete.name});
     expect(deletedApp).toMatchObject([appToDelete]);
-    expect(await ups.applications.find({filter: {name: appToDelete.name}})).toHaveLength(0);
+    expect((await ups.applications.find({filter: {name: appToDelete.name}})).appList).toHaveLength(0);
   });
 
   // VARIANTS TEST

--- a/test/applications/ApplicationsAdmin.test.ts
+++ b/test/applications/ApplicationsAdmin.test.ts
@@ -29,8 +29,8 @@ describe('Applications Admin', () => {
     expect(newApp.name).toEqual(NEW_APP_NAME);
 
     const allApps = await appAdmin.find(api);
-    expect(allApps).toHaveLength(1);
-    expect(allApps[0].name).toEqual(NEW_APP_NAME);
+    expect(allApps.appList).toHaveLength(1);
+    expect(allApps.appList[0].name).toEqual(NEW_APP_NAME);
   });
 
   it('Should rename the application.', async () => {
@@ -40,11 +40,11 @@ describe('Applications Admin', () => {
 
     const newName = 'NEW APP NAME';
 
-    expect((await appAdmin.find(api, {filter: {pushApplicationID: appId}}))[0].name).not.toEqual(newName);
+    expect((await appAdmin.find(api, {filter: {pushApplicationID: appId}})).appList[0].name).not.toEqual(newName);
 
     await appAdmin.update(api, {pushApplicationID: appId, name: newName} as PushApplication);
 
-    expect((await appAdmin.find(api, {filter: {pushApplicationID: appId}}))[0].name).toEqual(newName);
+    expect((await appAdmin.find(api, {filter: {pushApplicationID: appId}})).appList[0].name).toEqual(newName);
   });
 
   it('Should return all apps (1st page)', async () => {
@@ -52,34 +52,38 @@ describe('Applications Admin', () => {
     utils.generateApps(upsMock, 45, ids);
 
     const apps = await appAdmin.find(api);
-    expect(apps).toHaveLength(10);
-    expect(apps).toMatchObject(ids.slice(0, 10));
+    expect(apps.appList).toHaveLength(10);
+    expect(apps.appList).toMatchObject(ids.slice(0, 10));
+
+    expect(apps.total as number).toEqual(45);
   });
 
   it('Should return all apps (2nd page)', async () => {
     utils.generateApps(upsMock, 45);
 
     let apps = await appAdmin.find(api);
-    expect(apps).toHaveLength(10);
+    expect(apps.appList).toHaveLength(10);
     apps = await appAdmin.find(api, {page: 1});
-    expect(apps).toHaveLength(10);
+    expect(apps.appList).toHaveLength(10);
     apps = await appAdmin.find(api, {page: 2});
-    expect(apps).toHaveLength(10);
+    expect(apps.appList).toHaveLength(10);
     apps = await appAdmin.find(api, {page: 3});
-    expect(apps).toHaveLength(10);
+    expect(apps.appList).toHaveLength(10);
     apps = await appAdmin.find(api, {page: 4});
-    expect(apps).toHaveLength(5);
+    expect(apps.appList).toHaveLength(5);
+    expect(apps.total).toEqual(45);
   });
 
   it('Should return a given app', async () => {
     utils.generateApps(upsMock, 10);
     // get one app
-    const app = (await appAdmin.find(api))[6];
+    const app = (await appAdmin.find(api)).appList[6];
 
     const filteredApp = await appAdmin.find(api, {
       filter: {pushApplicationID: app.pushApplicationID},
     });
-    expect(filteredApp).toEqual([app]);
+    expect(filteredApp.appList).toEqual([app]);
+    expect(filteredApp.total).toEqual(1);
   });
 
   it('Should find app by name', async () => {
@@ -88,14 +92,15 @@ describe('Applications Admin', () => {
     // get one app
     const app = await appAdmin.find(api, {filter: {name: 'TEST'}});
 
-    expect(app).toHaveLength(1);
+    expect(app.appList).toHaveLength(1);
+    expect(app.total).toEqual(1);
   });
 
   it('Should return empty result', async () => {
     const filteredApp = await appAdmin.find(api, {
       filter: {developer: APP_DEVELOPER_FILTER_BAD},
     });
-    expect(filteredApp).toEqual([]);
+    expect(filteredApp.appList).toEqual([]);
   });
 
   it(`Should return all apps developed by ${APP_DEVELOPER_FILTER_OK}`, async () => {
@@ -106,8 +111,8 @@ describe('Applications Admin', () => {
     const filteredApp = await appAdmin.find(api, {
       filter: {developer: APP_DEVELOPER_FILTER_OK},
     });
-    expect(filteredApp).toHaveLength(8);
-    expect(filteredApp).toMatchObject(new Array(8).fill({developer: APP_DEVELOPER_FILTER_OK}));
+    expect(filteredApp.appList).toHaveLength(8);
+    expect(filteredApp.appList).toMatchObject(new Array(8).fill({developer: APP_DEVELOPER_FILTER_OK}));
   });
 
   it('Should delete an app using the Id ', async () => {
@@ -116,12 +121,12 @@ describe('Applications Admin', () => {
 
     const idToDelete = ids[5];
 
-    expect(await appAdmin.find(api)).toHaveLength(10);
-    expect(await appAdmin.find(api, {filter: idToDelete})).toHaveLength(1);
+    expect((await appAdmin.find(api)).appList).toHaveLength(10);
+    expect((await appAdmin.find(api, {filter: idToDelete})).appList).toHaveLength(1);
 
     await appAdmin.delete(api, idToDelete);
 
-    expect(await appAdmin.find(api)).toHaveLength(9);
-    expect(await appAdmin.find(api, {filter: idToDelete})).toHaveLength(0);
+    expect((await appAdmin.find(api)).appList).toHaveLength(9);
+    expect((await appAdmin.find(api, {filter: idToDelete})).appList).toHaveLength(0);
   });
 });

--- a/test/mocks/rest/applications.ts
+++ b/test/mocks/rest/applications.ts
@@ -57,20 +57,20 @@ export const mockGetApplications = (scope: nock.Scope, ups: UPSEngineMock, enfor
 
   // get application by id
 
-  scope = scope.get(/rest\/applications\/([^/]+)\?/).reply(200, function (uri: string) {
+  scope = scope.get(/rest\/applications\/([^/]+)\?/).reply(function (uri: string) {
     checkAuth(this.req, enforceAuth);
     const urlWithParam = /rest\/applications\/([^/]+)\?/;
     const urlParams = urlWithParam.exec(uri)!;
     const appId = urlParams[1];
-    return ups.getApplications(appId);
+    return [200, ups.getApplications(appId), {total: ups.countApplications()}];
   });
 
-  scope = scope.get(/rest\/applications\/([^/]+)$/).reply(200, function (uri: string) {
+  scope = scope.get(/rest\/applications\/([^/]+)$/).reply(function (uri: string) {
     checkAuth(this.req, enforceAuth);
     const urlWithParam = /rest\/applications\/([^/]+)$/;
     const urlParams = urlWithParam.exec(uri)!;
     const appId = urlParams[1];
-    return ups.getApplications(appId);
+    return [200, ups.getApplications(appId), {total: ups.countApplications()}];
   });
 
   return scope;


### PR DESCRIPTION
## Motivation
The UPS returns the applications one page at a a time.
We needed a way to know the total number of application so that we can paginate.

## What
The UPS /rest/applications endpojnt returns an header called 'total'
containing the total number of applications that match a given request
(that's very useful, since it returns the result only one page at a
time).

This implementation adds the ability to read that value and
implement the 'total' application management even for filters not
managed directly by the application server.

BREAKING CHANGE: This change will change the return value of the `find`
method

## Checklist:

- [X] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 