### PR TITLE
Aerogear 10279 - Added variant update api

### DIFF
--- a/src/variants/Variant.ts
+++ b/src/variants/Variant.ts
@@ -1,5 +1,11 @@
 export type VARIANT_TYPE = 'android' | 'ios' | 'ios_token' | 'web_push';
 
+export interface VariantUpdate {
+  variantID: string;
+  type: VARIANT_TYPE;
+  [key: string]: string;
+}
+
 export interface VariantFilter {
   id?: string;
   name?: string;

--- a/test/UnifiedPushAdminClient.test.ts
+++ b/test/UnifiedPushAdminClient.test.ts
@@ -135,6 +135,29 @@ describe('UnifiedPushAdminClient', () => {
     expect(renewedVariant.secret).not.toEqual(oldSecret);
   });
 
+  it('Should update a variant name', async () => {
+    const APP_IDS = utils.generateApps(upsMock, 10);
+    const appId = APP_IDS[5];
+    const variants = utils.generateVariants(upsMock, appId, 30);
+
+    const variantToRenew = variants[15];
+    const newName = 'new name';
+
+    await new UnifiedPushAdminClient(BASE_URL, credentials).variants.update(appId, {
+      variantID: variantToRenew.variantID!,
+      type: variantToRenew.type,
+      name: newName,
+    });
+
+    const updatedVariant = (
+      await new UnifiedPushAdminClient(BASE_URL, credentials).variants.find(appId, {
+        variantID: variantToRenew.variantID,
+      })
+    )[0];
+
+    expect(updatedVariant.name).toEqual(newName);
+  });
+
   it('Should renew a 404', async () => {
     const APP_IDS = utils.generateApps(upsMock, 10);
     const appId = APP_IDS[5];

--- a/test/mocks/engine/UPSEngineMock.ts
+++ b/test/mocks/engine/UPSEngineMock.ts
@@ -1,6 +1,6 @@
 import {PushApplication} from '../../../src/applications';
 import {Guid} from 'guid-typescript';
-import {Variant} from '../../../src/variants';
+import {AndroidVariant, Variant} from '../../../src/variants';
 
 export class UPSEngineMock {
   private data: PushApplication[] = [];
@@ -69,6 +69,31 @@ export class UPSEngineMock {
     }
 
     return app.variants ? app.variants.filter(variant => variant.type === type) : [];
+  }
+
+  updateVariant(appId: string, variant: Variant): Variant | null {
+    const app = this.data.find(app => app.pushApplicationID === appId);
+    if (!app) {
+      return null;
+    }
+
+    const variantToUpdate = app.variants?.find(v => v.variantID === variant?.variantID && v.type === variant.type);
+    if (!variantToUpdate) {
+      return null;
+    }
+
+    variantToUpdate.name = variant.name || variantToUpdate.name;
+    variantToUpdate.description = variant.description || variantToUpdate.description;
+    switch (variant.type) {
+      case 'android': {
+        const androidVariant = variantToUpdate as AndroidVariant;
+        const update = variant as AndroidVariant;
+        androidVariant.projectNumber = update.projectNumber || androidVariant.projectNumber;
+        androidVariant.googleKey = update.googleKey || androidVariant.googleKey;
+      }
+    }
+
+    return variantToUpdate;
   }
 
   deleteVariant(appId: string, type: string, variantId: string) {

--- a/test/mocks/rest/UPSMock.ts
+++ b/test/mocks/rest/UPSMock.ts
@@ -8,6 +8,7 @@ import {
   mockDeleteVariant,
   mockGetVariants,
   mockRenewVariantSecret,
+  mockUpdateVariant,
 } from './variants';
 import {mockKeyCloak} from './keycloak';
 
@@ -34,6 +35,7 @@ export class UPSMock {
     this.mockCreateiOSVariant();
     this.mockGetVariants();
     this.mockDeleteVariant();
+    this.mockUpdateVariant();
     this.mockRenewVariantSecret();
 
     this.mock.persist(true);
@@ -52,6 +54,7 @@ export class UPSMock {
   private mockCreateAndroidVariant = () => (this.mock = mockCreateAndroidVariant(this.mock, this.ups));
   private mockCreateiOSVariant = () => (this.mock = mockCreateiOSVariant(this.mock, this.ups));
   private mockDeleteVariant = () => (this.mock = mockDeleteVariant(this.mock, this.ups));
+  private mockUpdateVariant = () => (this.mock = mockUpdateVariant(this.mock, this.ups));
   private mockRenewVariantSecret = () => (this.mock = mockRenewVariantSecret(this.mock, this.ups));
 
   // State management

--- a/test/mocks/rest/variants.ts
+++ b/test/mocks/rest/variants.ts
@@ -109,3 +109,18 @@ export const mockRenewVariantSecret = (scope: nock.Scope, ups: UPSEngineMock) =>
     return [200, variant];
   });
 };
+
+export const mockUpdateVariant = (scope: nock.Scope, ups: UPSEngineMock) => {
+  return scope.put(/rest\/applications\/([^/]+)\/([^/]+)\/([^/]+)$/).reply((uri: string, requestBody: nock.Body) => {
+    const regex = /rest\/applications\/([^/]+)\/([^/]+)\/([^/]+)$/;
+    const urlParams = regex.exec(uri)!;
+    const appId = urlParams[1];
+
+    const variant = ups.updateVariant(appId, requestBody as Variant);
+    if (!variant) {
+      return [404, 'Could not find requested Variant'];
+    }
+
+    return [204];
+  });
+};

--- a/test/variants/VariantsAdmin.test.ts
+++ b/test/variants/VariantsAdmin.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import {VariantsAdmin} from '../../src/variants/VariantsAdmin';
 import {AndroidVariant, IOSVariant, Variant} from '../../src/variants';
 import {UPSMock, utils} from '../mocks';
+import {VariantUpdate} from '../../src/variants/Variant';
 
 const TEST_APP_ID = '2:2';
 const BASE_URL = 'http://localhost:8888';
@@ -187,5 +188,25 @@ describe('Variants Admin', () => {
     await expect(variantAdmin.renewSecret(api, APP_ID, 'android', 'bad id')).rejects.toThrow(
       'Request failed with status code 404'
     );
+  });
+
+  it('Should update a variant name', async () => {
+    const APP_IDS = utils.generateApps(upsMock, 10);
+    const APP_ID = APP_IDS[5];
+    const VARIANTS = utils.generateVariants(upsMock, APP_ID, 30);
+
+    const variantToUpdate = VARIANTS[12];
+    const newName = 'new name';
+    const update: VariantUpdate = {
+      variantID: variantToUpdate.variantID!,
+      type: variantToUpdate.type,
+      name: newName,
+    };
+
+    await variantAdmin.update(api, APP_ID, update);
+
+    const updatedVariant = (await variantAdmin.find(api, APP_ID, {variantID: variantToUpdate.variantID}))[0];
+
+    expect(updatedVariant.name).toEqual(newName);
   });
 });


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-10279

## Verification Steps
 
1. Open the UPS admin UI and create a variant
2. Take note of the variantid and the application id
3. Write a small program using this version of the client library and call the new api:
    ```javascript
    new UnifiedPushAdminClient('http://localhost:9999').
        variants.update('appId', { variantID: 'your variantID', type: 'your variant type', name: 'new name'} );
    ```
4. Refresh the AdminUI and verify that the variant name has changed

'name' is just an example: other properties can be changed too.