### PR TITLE
Webpush variant

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
 export {PushApplication, PushApplicationSearchOptions} from './applications';
-export {Variant, VariantFilter, VARIANT_TYPE, AndroidVariant, IOSVariant, IOSTokenVariant} from './variants';
+export {
+  Variant,
+  VariantFilter,
+  VARIANT_TYPE,
+  AndroidVariant,
+  IOSVariant,
+  IOSTokenVariant,
+  WebPushVariant,
+} from './variants';
 export {UnifiedPushAdminClient} from './UnifiedPushAdminClient';

--- a/src/variants/IOSVariant.ts
+++ b/src/variants/IOSVariant.ts
@@ -12,5 +12,7 @@ export interface IOSTokenVariant extends Variant {
   teamId: string;
   keyId: string;
   bundleId: string;
+  production: boolean;
+  privateKey: string; // private key in p8 format
   type: 'ios_token';
 }


### PR DESCRIPTION
## Motivation
WebPush Variant was not exported as public.
iOSTokeVariant was missing the privateKey and the production fields.

