### PR TITLE
fix: 🐛 variant metadata was not correctly populated

### DIFF
--- a/src/commands/applications/search/AbstractSearchCommand.ts
+++ b/src/commands/applications/search/AbstractSearchCommand.ts
@@ -10,15 +10,15 @@ export interface SearchResult {
 export abstract class AbstractSearchCommand {
   protected readonly addActivityData = (app: PushApplication, response: AxiosResponse): PushApplication => {
     app.metadata = {
-      activity: response.headers[`activity_app_${app.pushApplicationID.toLowerCase()}`],
-      deviceCount: response.headers[`devicecount_app_${app.pushApplicationID?.toLowerCase()}`],
+      activity: +response.headers[`activity_app_${app.pushApplicationID.toLowerCase()}`],
+      deviceCount: +response.headers[`devicecount_app_${app.pushApplicationID?.toLowerCase()}`],
     };
 
     // Add info to the variant
     app.variants = app.variants?.map(variant => {
       variant.metadata = {
-        activity: response.headers[`activity_variant_${app.pushApplicationID?.toLowerCase()}`],
-        deviceCount: response.headers[`devicecount_variant_${app.pushApplicationID?.toLowerCase()}`],
+        activity: +response.headers[`activity_variant_${variant.variantID?.toLowerCase()}`],
+        deviceCount: +response.headers[`devicecount_variant_${variant.variantID?.toLowerCase()}`],
       };
       return variant;
     });


### PR DESCRIPTION
## Motivation
There was an error in the header name that was used to populate the
variant metadata (activity and device count)

## What
Fixed the header name