### PR TITLE
ci: 🎡 codacy report didn't work anymore

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -3,7 +3,7 @@ name: codacy-coverage-reporter
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   codacy-coverage-reporter:


### PR DESCRIPTION
## Motivation
codacy report branch was wrong

## What
Fixed the branch in the github workflow